### PR TITLE
pinned genai version

### DIFF
--- a/lab/workshop-instructions/Lab5-Optimize-Model/requirements.txt
+++ b/lab/workshop-instructions/Lab5-Optimize-Model/requirements.txt
@@ -7,6 +7,4 @@ bitsandbytes==0.44.1
 accelerate>=0.30.0
 scipy==1.14.1
 azure-ai-ml==1.21.1
-#--extra-index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/
-#ort-nightly
-#onnxruntime-genai
+onnxruntime-genai-cuda==0.5.0


### PR DESCRIPTION
The Generate API for ONNX Runtime dependency has been pinned to version 0.5.0.